### PR TITLE
Upgrade dependencies and docs for new Action

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,8 +1,0 @@
-workflow "gitleaks my commits" {
-  on = "push"
-  resolves = ["gitleaks"]
-}
-
-action "gitleaks" {
-  uses = "eshork/gitleaks-action@master"
-}

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -10,4 +10,4 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
 
-      - uses: eshork/gitleaks-action@master
+      - uses: ${{ github.repository }}@master

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -10,4 +10,4 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
 
-      - uses: $GITHUB_REPOSITORY@master
+      - uses: eshork/gitleaks-action@master

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -10,4 +10,4 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
 
-      - uses: ${{ github.repository }}@master
+      - uses: $GITHUB_REPOSITORY@master

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,13 @@
+name: gitleaks my commits
+
+on:
+  - push
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - uses: eshork/gitleaks-action@master

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM zricethezav/gitleaks
+FROM zricethezav/gitleaks:v3.0.3
 
 LABEL "com.github.actions.name"="gitleaks-action"
 LABEL "com.github.actions.description"="checks your source for embedded key leaks, using gitleaks"

--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ jobs:
         uses: actions/checkout@v2
 
       - uses: eshork/gitleaks-action@master
+        env:
+          # GITLEAKS_REPO targets the repo to scan (default to GITHUB_WORKSPACE)
+          GITLEAKS_REPO: $GITHUB_WORKSPACE
+          # GITLEAKS_CONFIG targets the config to use (use `--repo-config` if not set)
+          GITLEAKS_CONFIG: $GITHUB_WORKSPACE/.github/gitleaks.toml
+          # GITLEAKS_EXTRA_ARGS allow to extra args to gitleaks
+          GITHUB_EXTRA_ARGS: --log=debug
 ```
 
 > Note: Avoid using master ref, prefer to pin the last release's SHA ref.

--- a/README.md
+++ b/README.md
@@ -5,15 +5,22 @@ Audit git commits for secrets with gitleaks, as a GitHub action.
 Credit to [zricethezav/gitleaks](https://github.com/zricethezav/gitleaks) for the complicated bits.
 
 ## Usage
-```
-workflow "gitleaks my commits" {
-  on = "push"
-  resolves = ["gitleaks"]
-}
 
-action "gitleaks" {
-  uses = "eshork/gitleaks-action@master"
-}
+```
+name: gitleaks my commits
+
+on:
+  - push
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - uses: eshork/gitleaks-action@master
+
 ```
 
 ----

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Credit to [zricethezav/gitleaks](https://github.com/zricethezav/gitleaks) for th
 
 ## Usage
 
-```
+```yaml
 name: gitleaks my commits
 
 on:
@@ -17,11 +17,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       - uses: eshork/gitleaks-action@master
-
 ```
+
+> Note: Avoid using master ref, prefer to pin the last release's SHA ref.
 
 ----
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,6 +4,16 @@ set -e # Abort script at first error
 set -u # nounset - Attempt to use undefined variable outputs error message, and forces an exit
 # set -x # verbose (expands commands)
 
+GITLEAKS_REPO=${GITLEAKS_REPO:-$GITHUB_WORKSPACE}
+GITLEAKS_CONFIG=${GITLEAKS_CONFIG:-}
+GITLEAKS_EXTRA_ARGS=${GITLEAKS_EXTRA_ARGS:-}
+
+if [ -n "$GITLEAKS_CONFIG" ]; then
+  GITLEAKS_EXTRA_ARGS="$GITLEAKS_EXTRA_ARGS --config=$GITLEAKS_CONFIG"
+else
+  GITLEAKS_EXTRA_ARGS="$GITLEAKS_EXTRA_ARGS --repo-config"
+fi
+
 gitleaks --verbose --redact --threads=1 \
-  --repo-path="$GITHUB_WORKSPACE" \
-  --repo-config
+  --repo-path="$GITLEAKS_REPO" \
+  $GITLEAKS_EXTRA_ARGS

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,8 +10,6 @@ GITLEAKS_EXTRA_ARGS=${GITLEAKS_EXTRA_ARGS:-}
 
 if [ -n "$GITLEAKS_CONFIG" ]; then
   GITLEAKS_EXTRA_ARGS="$GITLEAKS_EXTRA_ARGS --config=$GITLEAKS_CONFIG"
-else
-  GITLEAKS_EXTRA_ARGS="$GITLEAKS_EXTRA_ARGS --repo-config"
 fi
 
 gitleaks --verbose --redact --threads=1 \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,6 +4,6 @@ set -e # Abort script at first error
 set -u # nounset - Attempt to use undefined variable outputs error message, and forces an exit
 # set -x # verbose (expands commands)
 
-gitleaks -v --exclude-forks --redact --threads=1 \
-  --branch=$GITHUB_REF \
-  --repo-path=$GITHUB_WORKSPACE \
+gitleaks --verbose --redact --threads=1 \
+  --branch="$GITHUB_REF" \
+  --repo-path="$GITHUB_WORKSPACE"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,4 +5,5 @@ set -u # nounset - Attempt to use undefined variable outputs error message, and 
 # set -x # verbose (expands commands)
 
 gitleaks --verbose --redact --threads=1 \
-  --repo-path="$GITHUB_WORKSPACE"
+  --repo-path="$GITHUB_WORKSPACE" \
+  --repo-config

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,5 +5,4 @@ set -u # nounset - Attempt to use undefined variable outputs error message, and 
 # set -x # verbose (expands commands)
 
 gitleaks --verbose --redact --threads=1 \
-  --branch="$GITHUB_REF" \
   --repo-path="$GITHUB_WORKSPACE"


### PR DESCRIPTION
- Pinned Docker base image version (use [`Renovate`](https://github.com/apps/renovate) to upgrade automatically) 
- Gitleaks: Disable old `--exclude-forks` option
- Gitleaks: config file should be implicitly declared or `--repo-config` added with extra args
- Example with new Action notation 
- Add basic settings:
  - GITLEAKS_REPO
  - GITLEAKS_CONFIG
  - GITLEAKS_EXTRA_ARGS